### PR TITLE
Improve validation speed for valid files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-  "jsonschema>=4.4.0"
+  "jsonschema>=4.4.0",
+  "fastjsonschema>=2.16.2"
 ]
 
 [project.urls]


### PR DESCRIPTION
- Use fastjsonschema to improve the validation speed
- If the file is not valid, jsonschema is used to obtain all errors