### PR TITLE
docs: Update outdated references to raillabel.format.CoordinateSystem

### DIFF
--- a/raillabel/format/bbox.py
+++ b/raillabel/format/bbox.py
@@ -25,7 +25,7 @@ class Bbox(_Annotation):
     attributes: dict, optional
         Attributes of the annotation. Dict keys are the name str of the attribute, values are the
         attribute values. Default is {}.
-    sensor: raillabel.format.CoordinateSystem, optional
+    sensor: raillabel.format.Sensor, optional
         A reference to the sensor, this annotation is labeled in. Default is None.
     """
 

--- a/raillabel/format/cuboid.py
+++ b/raillabel/format/cuboid.py
@@ -29,7 +29,7 @@ class Cuboid(_Annotation):
     attributes: dict, optional
         Attributes of the annotation. Dict keys are the name str of the attribute, values are the
         attribute values. Default is {}.
-    sensor: raillabel.format.CoordinateSystem, optional
+    sensor: raillabel.format.Sensor, optional
         A reference to the sensor, this annotation is labeled in. Default is None.
     """
 

--- a/raillabel/format/num.py
+++ b/raillabel/format/num.py
@@ -22,7 +22,7 @@ class Num(_Annotation):
     attributes: dict, optional
         Attributes of the annotation. Dict keys are the uid str of the attribute, values are the
         attribute values. Default is {}.
-    sensor: raillabel.format.CoordinateSystem, optional
+    sensor: raillabel.format.Sensor, optional
         A reference to the sensor, this value is represented in. Default is None.
     """
 

--- a/raillabel/format/poly2d.py
+++ b/raillabel/format/poly2d.py
@@ -33,7 +33,7 @@ class Poly2d(_Annotation):
     attributes: dict, optional
         Attributes of the annotation. Dict keys are the name str of the attribute, values are the
         attribute values. Default is {}.
-    sensor: raillabel.format.CoordinateSystem, optional
+    sensor: raillabel.format.Sensor, optional
         A reference to the sensor, this annotation is labeled in. Default is None.
     """
 

--- a/raillabel/format/poly3d.py
+++ b/raillabel/format/poly3d.py
@@ -26,7 +26,7 @@ class Poly3d(_Annotation):
     attributes: dict, optional
         Attributes of the annotation. Dict keys are the name str of the attribute, values are the
         attribute values. Default is {}.
-    sensor: raillabel.format.CoordinateSystem, optional
+    sensor: raillabel.format.Sensor, optional
         A reference to the sensor, this annotation is labeled in. Default is None.
     """
 

--- a/raillabel/format/seg3d.py
+++ b/raillabel/format/seg3d.py
@@ -21,7 +21,7 @@ class Seg3d(_Annotation):
         The list of point indices.
     attributes: dict, optional
         Attributes of the annotation. Default is {}.
-    sensor: raillabel.format.CoordinateSystem, optional
+    sensor: raillabel.format.Sensor, optional
         The sensor, this annotation is labeled in. Default is None.
     """
 


### PR DESCRIPTION
Some docstrings contained a reference to raillabel.format.CoordinateSystem, which has been replaced by raillabel.format.Sensor in commit 3713184f66a4ab8641f656d560d17edb8f9da06c.

This PR updates the affected docstrings.