### PR TITLE
feat: Add load_from_string

### DIFF
--- a/raillabel/__init__.py
+++ b/raillabel/__init__.py
@@ -7,7 +7,7 @@ from . import format
 from .exceptions import *
 from .filter import filter
 from .format.scene import Scene
-from .load import load
+from .load import load, load_from_string
 from .save import save
 from .validate import validate
 

--- a/tests/test_raillabel/test_load.py
+++ b/tests/test_raillabel/test_load.py
@@ -18,6 +18,14 @@ def test_load_raillabel(json_paths):
     assert len(scene.frames) != 0
 
 
+def test_load_from_string_raillabel(json_paths):
+    data_path = json_paths["openlabel_v1_short"]
+    with open(data_path) as file:
+        json_string = file.read()
+    scene = raillabel.load_from_string(json_string)
+    assert len(scene.frames) != 0
+
+
 def test_load_uai(json_paths):
     data_path = json_paths["understand_ai_t4_short"]
     scene = raillabel.load(data_path)


### PR DESCRIPTION
### Summary

This PR adds a function `load_from_string`. For this, I have split up the existing `load` function.

### Use case

Currently, if you want to modify a raillabel json file *before* loading it using raillabel's `load`, you have to save the modified json to disk first. Using `load_from_string`, you can skip creating a temporary file on disk.

### Notes for reviewer

As a side effect of moving most of the code from `load` into `load_from_string`, the `path` variable isn't accessible anymore when printing warnings, so the filename isn't printed anymore. I could have added an optional `path` variable to `load_from_string` as a workaround, but I didn't want to expose that workaround to the API. Please suggest an alternative solution if this is a problem.