### PR TITLE
Fix code blocks in Docstrings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8"
+          python-version: "3.12"
       - name: Upgrade pip
         run: |
           python -m pip install -U pip
@@ -27,7 +27,7 @@ jobs:
           python -m pip install '.[docs]'
       - name: Auto-generate APIDOC sources
         run: |-
-          sphinx-apidoc --output-dir docs/source/code --force .
+          sphinx-apidoc --output-dir docs/source/code --force . --no-toc --private --separate
       - name: Create docs
         run: |
           make -C docs html

--- a/raillabel/__init__.py
+++ b/raillabel/__init__.py
@@ -4,41 +4,44 @@
 
 The first step in using raillabel is downloading a desired dataset
 (like [OSDaR23](https://data.fid-move.de/dataset/osdar23)). You can then load any scene by running
-```
-```
-import raillabel
 
-scene = raillabel.load("path/to/annotation_file.json")
-```
+.. code-block:: python
+
+    import raillabel
+
+    scene = raillabel.load("path/to/annotation_file.json")
 
 This returns the root class for the annotations.
 
 If a file is too extensive for your use-case you can filter out certain parts of a scene like this
-```
-from raillabel.filter import (
-    IncludeObjectTypeFilter,
-    ExcludeAnnotationTypeFilter,
-    StartTimeFilter, ExcludeFrameIdFilter,
-    IncludeAttributesFilter
-)
 
-scene_with_only_trains = scene.filter([IncludeObjectTypeFilter(["rail_vehicle"])])
+.. code-block:: python
 
-scene_without_bboxs = scene.filter([ExcludeAnnotationTypeFilter(["bbox"])])
+    from raillabel.filter import (
+        IncludeObjectTypeFilter,
+        ExcludeAnnotationTypeFilter,
+        StartTimeFilter, ExcludeFrameIdFilter,
+        IncludeAttributesFilter
+    )
 
-cut_scene_with_only_red_trains = scene.filter([
-    StartTimeFilter("1587349200.004200000"),
-    ExcludeFrameIdFilter([2, 4]),
-    IncludeObjectTypeFilter(["rail_vehicle"]),
-    IncludeAttributesFilter({"color": "red"}),
-])
-```
+    scene_with_only_trains = scene.filter([IncludeObjectTypeFilter(["rail_vehicle"])])
+
+    scene_without_bboxs = scene.filter([ExcludeAnnotationTypeFilter(["bbox"])])
+
+    cut_scene_with_only_red_trains = scene.filter([
+        StartTimeFilter("1587349200.004200000"),
+        ExcludeFrameIdFilter([2, 4]),
+        IncludeObjectTypeFilter(["rail_vehicle"]),
+        IncludeAttributesFilter({"color": "red"}),
+    ])
+
 An overview of all available filters can be found [here](https://dsd-dbs.github.io/raillabel/code/raillabel.filter.html#module-raillabel.filter).
 
 If you then want to save your changes, then use
-```
-raillabel.save(cut_scene_with_only_red_trains, "/path/to/target.json")
-```
+
+.. code-block:: python
+
+    raillabel.save(cut_scene_with_only_red_trains, "/path/to/target.json")
 """
 
 from importlib import metadata

--- a/raillabel/format/frame_interval.py
+++ b/raillabel/format/frame_interval.py
@@ -31,15 +31,13 @@ class FrameInterval:
         """Convert a list of frame uids into FrameIntervals.
 
         Example:
-        -------
-        ```python
-        FrameInterval.from_frame_ids([0, 1, 2, 3, 9, 12, 13, 14]) == [
-            FrameInterval(0, 3),
-            FrameInterval(9, 9),
-            FrameInterval(12, 14),
-        ]
-        ```
+        .. code-block:: python
 
+            FrameInterval.from_frame_ids([0, 1, 2, 3, 9, 12, 13, 14]) == [
+                FrameInterval(0, 3),
+                FrameInterval(9, 9),
+                FrameInterval(12, 14),
+            ]
         """
         sorted_frame_ids = sorted(frame_ids)
         frame_id_intervals = _slice_into_intervals(sorted_frame_ids)

--- a/raillabel/format/scene.py
+++ b/raillabel/format/scene.py
@@ -41,17 +41,19 @@ class Scene:
 
     Examples:
     You can load scenes like this:
-    ```
-    import raillabel
-    scene = raillabel.load("path/to/scene.json")
-    ```
+
+    .. code-block:: python
+
+        import raillabel
+        scene = raillabel.load("path/to/scene.json")
 
     The scenes then contain all of the data. This is how you can iterate over the annotations:
-    ```
-    for frame in scene.frames.values():
-        for annotation in frame.annotations.values():
-            pass  # do something with the annotation here
-    ```
+
+    .. code-block:: python
+
+        for frame in scene.frames.values():
+            for annotation in frame.annotations.values():
+                pass  # do something with the annotation here
     """
 
     metadata: Metadata
@@ -101,25 +103,26 @@ class Scene:
         """Return a scene with annotations, sensors, objects and frames excluded.
 
         Example:
-        ```
-        from raillabel.filter import (
-            IncludeObjectTypeFilter,
-            ExcludeAnnotationTypeFilter,
-            StartTimeFilter, ExcludeFrameIdFilter,
-            IncludeAttributesFilter
-        )
 
-        scene_with_only_trains = scene.filter([IncludeObjectTypeFilter(["rail_vehicle"])])
+        .. code-block:: python
 
-        scene_without_bboxs = scene.filter([ExcludeAnnotationTypeFilter(["bbox"])])
+            from raillabel.filter import (
+                IncludeObjectTypeFilter,
+                ExcludeAnnotationTypeFilter,
+                StartTimeFilter, ExcludeFrameIdFilter,
+                IncludeAttributesFilter
+            )
 
-        cut_scene_with_only_red_trains = scene.filter([
-            StartTimeFilter("1587349200.004200000"),
-            ExcludeFrameIdFilter([2, 4]),
-            IncludeObjectTypeFilter(["rail_vehicle"]),
-            IncludeAttributesFilter({"color": "red"}),
-        ])
-        ```
+            scene_with_only_trains = scene.filter([IncludeObjectTypeFilter(["rail_vehicle"])])
+
+            scene_without_bboxs = scene.filter([ExcludeAnnotationTypeFilter(["bbox"])])
+
+            cut_scene_with_only_red_trains = scene.filter([
+                StartTimeFilter("1587349200.004200000"),
+                ExcludeFrameIdFilter([2, 4]),
+                IncludeObjectTypeFilter(["rail_vehicle"]),
+                IncludeAttributesFilter({"color": "red"}),
+            ])
         """
         frame_filters, annotation_filters = _separate_filters(filters)
 

--- a/raillabel/load/load.py
+++ b/raillabel/load/load.py
@@ -14,10 +14,11 @@ def load(path: Path | str) -> Scene:
     """Load an annotation file as a scene.
 
     Example:
-    ```
-    import raillabel
-    scene = raillabel.load("path/to/scene.json")
-    ```
+
+    .. code-block:: python
+
+        import raillabel
+        scene = raillabel.load("path/to/scene.json")
     """
     with Path(path).open() as annotation_file:
         json_data = json.load(annotation_file)

--- a/raillabel/save/save.py
+++ b/raillabel/save/save.py
@@ -12,16 +12,17 @@ def save(scene: Scene, path: Path | str, prettify_json: bool = False) -> None:
     """Save a raillabel.Scene to a JSON file.
 
     Example:
-    ```
-    import raillabel
-    scene = raillabel.load("path/to/scene.json")
 
-    # change something about the scene
+    .. code-block:: python
 
-    raillabel.save(scene, "path/to/new_scene.json")
-    # or to get a readable (but much larger) file
-    raillabel.save(scene, "path/to/new_scene.json", prettify_json=True)
-    ```
+        import raillabel
+        scene = raillabel.load("path/to/scene.json")
+
+        # change something about the scene
+
+        raillabel.save(scene, "path/to/new_scene.json")
+        # or to get a human readable (but much larger) file
+        raillabel.save(scene, "path/to/new_scene.json", prettify_json=True)
     """
     if prettify_json:
         json_data = scene.to_json().model_dump_json(exclude_none=True, indent=4)

--- a/raillabel/scene_builder/scene_builder.py
+++ b/raillabel/scene_builder/scene_builder.py
@@ -104,10 +104,17 @@ class SceneBuilder:
         another frame_id.
 
         Example:
-        ```python
-        scene = SceneBuilder.empty().add_frame(frame_id=1).add_frame(frame_id=3).add_frame().result
-        assert sorted(list(scene.frames.keys())) == [1, 2, 3]
-        ```
+
+        .. code-block:: python
+
+            scene = (
+                SceneBuilder.empty()
+                    .add_frame(frame_id=1)
+                    .add_frame(frame_id=3)
+                    .add_frame()
+                    .result
+            )
+            assert sorted(list(scene.frames.keys())) == [1, 2, 3]
         """
         scene = deepcopy(self.result)
 


### PR DESCRIPTION
The code blocks inside python docstrings were displayed weirdly in the Sphinx online documentation. This PR fixes this.