### PR TITLE
Object name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,6 @@ New features:
 # 4.1.1
 - `Scene.filter()` now also removes unused sensors from `Frame.sensors`
 - `SceneBuilder` now also automatically adds sensors to `Frame.sensor` if a frame has a timestamp value
+
+# 4.1.2
+- fixed a bug where the `SceneBuilder` created an `Object` with the wrong type from the object name if the object name contained more than one underscore (for example `SceneBuilder.add_object(object_name="signal_bridge_0001")` created an object with type `signal` before where now it creates an object with the correct type `signal_bridge`)

--- a/raillabel/scene_builder/scene_builder.py
+++ b/raillabel/scene_builder/scene_builder.py
@@ -309,7 +309,8 @@ def _resolve_empty_object_name_or_type(
         return object_type, object_name
 
     if object_name is not None and object_type is None:
-        object_type = object_name.split("_")[0]
+        length_of_object_suffix = len(object_name.split("_")[-1]) + 1
+        object_type = object_name[: len(object_name) - length_of_object_suffix]
         return object_type, object_name
 
     if object_name is not None and object_type is not None:

--- a/tests/scene_builder/test_scene_builder.py
+++ b/tests/scene_builder/test_scene_builder.py
@@ -140,6 +140,20 @@ def test_add_object__object_id_iteration():
     )
 
 
+def test_add_object__object_name_with_underscore():
+    actual = SceneBuilder.empty().add_object(object_name="signal_bridge_0001").result
+
+    actual.to_json()  # check if scene is also valid in JSON
+    assert actual == Scene(
+        metadata=Metadata(schema_version="1.0.0"),
+        objects={
+            UUID("5c59aad4-0000-4000-0000-000000000000"): Object(
+                name="signal_bridge_0001", type="signal_bridge"
+            )
+        },
+    )
+
+
 def test_add_sensor__camera_rgb(camera_empty):
     actual = SceneBuilder.empty().add_sensor("rgb_center").result
 


### PR DESCRIPTION
- fixed a bug where the `SceneBuilder` created an `Object` with the wrong type from the object name if the object name contained more than one underscore (for example `SceneBuilder.add_object(object_name="signal_bridge_0001")` created an object with type `signal` before where now it creates an object with the correct type `signal_bridge`)